### PR TITLE
Fix typos raised by mebelz

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -651,7 +651,7 @@
     .style("left", "0px")
     .style("position", "absolute")
       .style("padding", "10px")
-    .html("The data comes in 2 clusters. The first 2 eigenfeatures captures variations between the clusters. ")
+    .html("The data comes in 2 clusters. The first 2 eigenfeatures capture variations between the clusters. ")
 
     annotate.append("figcaption")
     .style("width", 230 + "px")
@@ -888,7 +888,7 @@ instead. Note that this decay is dependent on the stepsize.
   -\alpha\beta & 1-\alpha\lambda_{i}
   \end{array}\!\!\right).
   $$
-  There are many ways of taking a matrix to the $k^{th}$ power. But for the $2 \times 2$ case there is an elegant and little known formula <dt-cite key="williamsnthpower"></dt-cite> in terms of the eigenvectors of $R$, $\sigma_1$ and $\sigma_2$.
+  There are many ways of taking a matrix to the $k^{th}$ power. But for the $2 \times 2$ case there is an elegant and little known formula <dt-cite key="williamsnthpower"></dt-cite> in terms of the eigenvalues of $R$, $\sigma_1$ and $\sigma_2$.
 
   $$
 \color{#AAA}{\color{black}{R^{k}}=\begin{cases}


### PR DESCRIPTION
Fix the typos raised by mebelz in #68

The first 2 eigenfeatures captures variations -> capture
in terms of the eigenvectors of -> eigenvalues